### PR TITLE
Fix bad header title in slider

### DIFF
--- a/css/components/_activity-slider.scss
+++ b/css/components/_activity-slider.scss
@@ -4,8 +4,6 @@
   }
 
   h3 {
-    position: relative;
-    left: -2.5em;
     margin-top: 1em;
     color: black;
     text-shadow: 2px 0 rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
This feature turn this:
![screen shot 2019-01-16 at 10 40 14 am](https://user-images.githubusercontent.com/35476736/51257095-432ade00-197d-11e9-9e56-e60c3e75aea6.png)

Into this:
![screen shot 2019-01-16 at 10 56 22 am](https://user-images.githubusercontent.com/35476736/51257191-74a3a980-197d-11e9-85de-e3da21827cb7.png)

The "position: relative" and "left" attributes are unnecessary so these attributes are causing this bad effect in the title.